### PR TITLE
Fix for points not being read

### DIFF
--- a/addons/sourcemod/scripting/rockthevote.sp
+++ b/addons/sourcemod/scripting/rockthevote.sp
@@ -359,7 +359,7 @@ public void db_selectPlayersDataCallback(Handle owner, Handle hndl, const char[]
 	if (SQL_HasResultSet(hndl) && SQL_FetchRow(hndl))
 	{
 		rank = SQL_GetRowCount(hndl);
-		points = SQL_FetchInt(hndl, 0);
+		points = SQL_FetchInt(hndl, 1);
 	}
 	else
 		rank = 99999;


### PR DESCRIPTION
Wrong database handle causes points not to be read which causes g_Voters and g_VotesNeeded to be set to 0